### PR TITLE
Include the Multicall2 version of the contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,15 +462,17 @@ console.log(results);
 
 by default it looks at your network from the provider you passed in and makes the contract address to that:
 
-- mainnet > '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'
-- kovan > '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'
-- görli > '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'
-- rinkeby > '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'
-- ropsten > '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696'
-- binance smart chain > '0xAf379C844f87A7b47EE6fe5E4a9720988EaEA0AF'
-- xdai > '0x2325b72990D81892E0e09cdE5C80DD221F147F8B'
-- mumbai > '0x73f44534C4bCb557FDf03a04A7b25018d6FcacD6'
-- matic > '0x5F42C143026e65E25aa76829DbCD6D4F0C9De8ED'
+| Network | Address |
+| ------- | ------- |
+| mainnet | `0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696` |
+| kovan | `0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696` |
+| görli | `0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696` |
+| rinkeby | `0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696` |
+| ropsten | `0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696` |
+| binance smart chain | `0xAf379C844f87A7b47EE6fe5E4a9720988EaEA0AF` |
+| xdai | `0x2325b72990D81892E0e09cdE5C80DD221F147F8B` |
+| mumbai | `0xe9939e7Ea7D7fb619Ac57f648Da7B1D425832631` |
+| matic | `0x275617327c958bD06b5D6b871E7f491D76113dd8` |
 
 If you wanted this to point at a different multicall contract address just pass that in the options when creating the multicall instance, example:
 

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -387,12 +387,13 @@ export class Multicall {
   private async executeWithEthersOrCustom(
     calls: AggregateCallContext[]
   ): Promise<AggregateResponse> {
-    let ethersProvider =
-      this.getTypedOptions<MulticallOptionsEthers>().ethersProvider;
+    let ethersProvider = this.getTypedOptions<MulticallOptionsEthers>()
+      .ethersProvider;
 
     if (!ethersProvider) {
-      const customProvider =
-        this.getTypedOptions<MulticallOptionsCustomJsonRpcProvider>();
+      const customProvider = this.getTypedOptions<
+        MulticallOptionsCustomJsonRpcProvider
+      >();
       if (customProvider.nodeUrl) {
         ethersProvider = new ethers.providers.JsonRpcProvider(
           customProvider.nodeUrl
@@ -488,7 +489,7 @@ export class Multicall {
    * Get typed options
    */
   private getTypedOptions<T>(): T {
-    return this._options as unknown as T;
+    return (this._options as unknown) as T;
   }
 
   /**
@@ -514,9 +515,9 @@ export class Multicall {
       case Networks.xdai:
         return '0x2325b72990D81892E0e09cdE5C80DD221F147F8B';
       case Networks.mumbai:
-        return '0xe9939e7Ea7D7fb619Ac57f648Da7B1D425832631';
+        return '0x73f44534C4bCb557FDf03a04A7b25018d6FcacD6';
       case Networks.matic:
-        return '0x275617327c958bD06b5D6b871E7f491D76113dd8';
+        return '0x5F42C143026e65E25aa76829DbCD6D4F0C9De8ED';
       default:
         throw new Error(
           `Network - ${network} is not got a contract defined it only supports mainnet, kovan, rinkeby, bsc and ropsten`

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -387,13 +387,12 @@ export class Multicall {
   private async executeWithEthersOrCustom(
     calls: AggregateCallContext[]
   ): Promise<AggregateResponse> {
-    let ethersProvider = this.getTypedOptions<MulticallOptionsEthers>()
-      .ethersProvider;
+    let ethersProvider =
+      this.getTypedOptions<MulticallOptionsEthers>().ethersProvider;
 
     if (!ethersProvider) {
-      const customProvider = this.getTypedOptions<
-        MulticallOptionsCustomJsonRpcProvider
-      >();
+      const customProvider =
+        this.getTypedOptions<MulticallOptionsCustomJsonRpcProvider>();
       if (customProvider.nodeUrl) {
         ethersProvider = new ethers.providers.JsonRpcProvider(
           customProvider.nodeUrl
@@ -489,7 +488,7 @@ export class Multicall {
    * Get typed options
    */
   private getTypedOptions<T>(): T {
-    return (this._options as unknown) as T;
+    return this._options as unknown as T;
   }
 
   /**
@@ -515,9 +514,9 @@ export class Multicall {
       case Networks.xdai:
         return '0x2325b72990D81892E0e09cdE5C80DD221F147F8B';
       case Networks.mumbai:
-        return '0x73f44534C4bCb557FDf03a04A7b25018d6FcacD6';
+        return '0xe9939e7Ea7D7fb619Ac57f648Da7B1D425832631';
       case Networks.matic:
-        return '0x5F42C143026e65E25aa76829DbCD6D4F0C9De8ED';
+        return '0x275617327c958bD06b5D6b871E7f491D76113dd8';
       default:
         throw new Error(
           `Network - ${network} is not got a contract defined it only supports mainnet, kovan, rinkeby, bsc and ropsten`

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -515,9 +515,9 @@ export class Multicall {
       case Networks.xdai:
         return '0x2325b72990D81892E0e09cdE5C80DD221F147F8B';
       case Networks.mumbai:
-        return '0x73f44534C4bCb557FDf03a04A7b25018d6FcacD6';
+        return '0xe9939e7Ea7D7fb619Ac57f648Da7B1D425832631';
       case Networks.matic:
-        return '0x5F42C143026e65E25aa76829DbCD6D4F0C9De8ED';
+        return '0x275617327c958bD06b5D6b871E7f491D76113dd8';
       default:
         throw new Error(
           `Network - ${network} is not got a contract defined it only supports mainnet, kovan, rinkeby, bsc and ropsten`


### PR DESCRIPTION
This PR provides fixes #8. 
The issue was related to contracts probably pointing to a v1 for the Multicall that was failing when accessed with the `tryAggregate` functionality. As there aren't official deployments of M2 in the Maker team's repo, I've deployed and verified new contracts for both polygon networks.

Matic: [`0x275617327c958bD06b5D6b871E7f491D76113dd8`](https://polygonscan.com/address/0x275617327c958bD06b5D6b871E7f491D76113dd8#code)
Mumbai: [`0xe9939e7Ea7D7fb619Ac57f648Da7B1D425832631`](https://mumbai.polygonscan.com/address/0xe9939e7Ea7D7fb619Ac57f648Da7B1D425832631#code)