### PR TITLE
Fix finding the output types from abi definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,64 @@ $ yarn add ethereum-multicall
 ```
 
 ## Usage
+### Overloaded methods
+As the [official docs mentions here](https://docs.ethers.io/v3/api-contract.html#prototype):
 
+> Due to signature overloading, multiple functions can have the same name. The first function specifed in the ABI will be bound to its name. To access overloaded functions, use the full typed signature of the functions (e.g. contract["foobar(address,uint256)"]).
+
+So, when creating the contract call context, under the calls array property we should have that in mind and use the method signature rather than the method name. E.g.
+```js
+const contractCallContext: ContractCallContext = {
+    reference: 'upV2Controller',
+    contractAddress: '0x19891DdF6F393C02E484D7a942d4BF8C0dB1d001',
+    abi: [
+      {
+        inputs: [],
+        name: 'getVirtualPrice',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            internalType: 'uint256',
+            name: 'sentValue',
+            type: 'uint256',
+          },
+        ],
+        name: 'getVirtualPrice',
+        outputs: [
+          {
+            internalType: 'uint256',
+            name: '',
+            type: 'uint256',
+          },
+        ],
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ],
+    calls: [
+      {
+        reference: 'getVirtualPriceWithInput',
+        methodName: 'getVirtualPrice(uint256)',
+        methodParameters: ['0xFFFFFFFFFFFFF'],
+      },
+      {
+        reference: 'getVirtualPriceWithoutInput',
+        methodName: 'getVirtualPrice()',
+        methodParameters: [],
+      },
+    ],
+  };
+```
 ### Import examples:
 
 ### JavaScript (ES3)

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -344,11 +344,17 @@ export class Multicall {
 
     return undefined;
   }
+
+  /**
+   * Build a mehtod signature from the abi item
+   * @param abiItem AbiItem
+   */
   private buildAbiItemSignature(abiItem: AbiItem) {
     const abiMethodParamTypes =
       abiItem.inputs?.map((input) => input.type.trim()).join(',') || '';
     return `${abiItem.name?.trim()}(${abiMethodParamTypes})`;
   }
+
   /**
    * Execute the multicall contract call
    * @param calls The calls

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -332,14 +332,23 @@ export class Multicall {
     methodName: string
   ): AbiOutput[] | undefined {
     for (let i = 0; i < abi.length; i++) {
-      if (abi[i].name?.trim() === methodName.trim()) {
+      methodName = methodName.trim();
+      const abiMethodName = abi[i].name?.trim();
+      if (abiMethodName === methodName) {
+        return abi[i].outputs;
+      }
+      if (methodName === this.buildAbiItemSignature(abi[i])) {
         return abi[i].outputs;
       }
     }
 
     return undefined;
   }
-
+  private buildAbiItemSignature(abiItem: AbiItem) {
+    const abiMethodParamTypes =
+      abiItem.inputs?.map((input) => input.type.trim()).join(',') || '';
+    return `${abiItem.name?.trim()}(${abiMethodParamTypes})`;
+  }
   /**
    * Execute the multicall contract call
    * @param calls The calls

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -331,28 +331,22 @@ export class Multicall {
     abi: AbiItem[],
     methodName: string
   ): AbiOutput[] | undefined {
+    const contract = new ethers.Contract(
+      ethers.constants.AddressZero,
+      abi as any
+    );
+    methodName = methodName.trim();
+    if (contract.interface.functions[methodName]) {
+      return contract.interface.functions[methodName].outputs;
+    }
+
     for (let i = 0; i < abi.length; i++) {
-      methodName = methodName.trim();
-      const abiMethodName = abi[i].name?.trim();
-      if (abiMethodName === methodName) {
-        return abi[i].outputs;
-      }
-      if (methodName === this.buildAbiItemSignature(abi[i])) {
+      if (abi[i].name?.trim() === methodName) {
         return abi[i].outputs;
       }
     }
 
     return undefined;
-  }
-
-  /**
-   * Build a mehtod signature from the abi item
-   * @param abiItem AbiItem
-   */
-  private buildAbiItemSignature(abiItem: AbiItem) {
-    const abiMethodParamTypes =
-      abiItem.inputs?.map((input) => input.type.trim()).join(',') || '';
-    return `${abiItem.name?.trim()}(${abiMethodParamTypes})`;
   }
 
   /**


### PR DESCRIPTION
If we have in the abi several methods with different inputs we aren't going to just put the method name but the signature, to allow the ethers package distinguise which one is using. So I am extending it to find AbiItem when a method signature is given.