### PR TITLE
Update bsc testnet contract address

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ by default it looks at your network from the provider you passed in and makes th
 | rinkeby             | `0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696` |
 | ropsten             | `0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696` |
 | binance smart chain | `0xC50F4c1E81c873B2204D7eFf7069Ffec6Fbe136D` |
-| bsc testnet         | `0x6e5BB1a5Ad6F68A8D7D6A5e47750eC15773d6042` |
+| bsc testnet         | `0x73CCde5acdb9980f54BcCc0483B28B8b4a537b4A` |
 | xdai                | `0x2325b72990D81892E0e09cdE5C80DD221F147F8B` |
 | mumbai              | `0xe9939e7Ea7D7fb619Ac57f648Da7B1D425832631` |
 | etherlite           | `0x21681750D7ddCB8d1240eD47338dC984f94AF2aC` |

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -554,7 +554,7 @@ export class Multicall {
       case Networks.bsc:
         return '0xC50F4c1E81c873B2204D7eFf7069Ffec6Fbe136D';
       case Networks.bsc_testnet:
-        return '0x6e5BB1a5Ad6F68A8D7D6A5e47750eC15773d6042';
+        return '0x73CCde5acdb9980f54BcCc0483B28B8b4a537b4A';
       case Networks.xdai:
         return '0x2325b72990D81892E0e09cdE5C80DD221F147F8B';
       case Networks.mumbai:


### PR DESCRIPTION
@joshstevens19 
It seems to be a version that does not reflect the try Aggregate attribute of the contract deployed to bsc testnet. So I redeployed the latest version of the Ethereum multicall contract to the bsc testnet.
Please check the contract address below.

BSC Testnet : 0x73CCde5acdb9980f54BcCc0483B28B8b4a537b4A

Thanks for making such a great project.😄