### PR TITLE
Add linea-testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The below networks are supported by default, and custom networks can be supporte
 | Milkomeda               | 2001       |
 | KCC                     | 321        |
 | Etherlite               | 111        |
+| Linea Testnet		  | 59140      |
 
 ## Installation
 

--- a/src/enums/networks.ts
+++ b/src/enums/networks.ts
@@ -48,4 +48,5 @@ export enum Networks {
   milkomeda = 2001,
   kcc = 321,
   etherlite = 111,
+  linea-testnet = 59140
 }

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -594,6 +594,7 @@ export class Multicall {
       case Networks.klatyn:
       case Networks.milkomeda:
       case Networks.kcc:
+      case Networks.linea-testnet:
         return '0xcA11bde05977b3631167028862bE2a173976CA11';
       case Networks.etherlite:
         return '0x21681750D7ddCB8d1240eD47338dC984f94AF2aC';


### PR DESCRIPTION
Added Linea Testnet support for the Multicall3 contract address 0xcA11bde05977b3631167028862bE2a173976CA11

network name: linea-testnet (to keep consistency with wagmi)