### PR TITLE
Added starknet to list of networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The below networks are supported by default, and custom networks can be supporte
 | Zora Testnet          | 999        |
 | Flare Mainnet         | 14         |
 | Pulsechain Mainnet    | 369        |
+| Starknet              | 300        |
+| starknet testnet      | 301        |
 
 ## Installation
 

--- a/src/enums/networks.ts
+++ b/src/enums/networks.ts
@@ -58,6 +58,8 @@ export enum Networks {
   zkSyncEra = 324,
   zkSyncEraTestnet = 280,
   zkSyncEraSepoliaTestnet = 300,
+  starknet=300,
+  starknetTestnet=301,
   shibarium = 109,
   mantle = 5000,
   mantleTestnet = 5001,

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -421,13 +421,12 @@ export class Multicall {
     calls: AggregateCallContext[],
     options: ContractCallOptions
   ): Promise<AggregateResponse> {
-    let ethersProvider = this.getTypedOptions<MulticallOptionsEthers>()
-      .ethersProvider;
+    let ethersProvider =
+      this.getTypedOptions<MulticallOptionsEthers>().ethersProvider;
 
     if (!ethersProvider) {
-      const customProvider = this.getTypedOptions<
-        MulticallOptionsCustomJsonRpcProvider
-      >();
+      const customProvider =
+        this.getTypedOptions<MulticallOptionsCustomJsonRpcProvider>();
       if (customProvider.nodeUrl) {
         ethersProvider = new ethers.providers.JsonRpcProvider(
           customProvider.nodeUrl
@@ -531,7 +530,7 @@ export class Multicall {
    * Get typed options
    */
   private getTypedOptions<T>(): T {
-    return (this._options as unknown) as T;
+    return this._options as unknown as T;
   }
 
   /**
@@ -620,6 +619,11 @@ export class Multicall {
         return '0xF9cda624FBC7e059355ce98a31693d299FACd963';
       case Networks.shibarium:
         return '0xd1727fC8F78aBA7DD6294f6033D74c72Ccd3D3B0';
+      case Networks.starknet:
+        return '0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4';
+      case Networks.starknetTestnet:
+        return '0xde29d060D45901Fb19ED6C6e959EB22d8626708e';
+
       default:
         throw new Error(
           `Network - ${network} doesn't have a multicall contract address defined. Please check your network or deploy your own contract on it.`


### PR DESCRIPTION
This pull request adds support for the StarkNet network in the existing switch statement. The StarkNet network, along with its testnet variants, are now included to provide users with seamless integration when interacting with contracts on these networks.