### PR TITLE
Fix Base Sepolia (testnet) ChainId

### DIFF
--- a/src/enums/networks.ts
+++ b/src/enums/networks.ts
@@ -64,7 +64,7 @@ export enum Networks {
   mantle = 5000,
   mantleTestnet = 5001,
   base = 8453,
-  baseTestnet = 84531,
+  baseTestnet = 84532,
   blastSepolia = 168587773,
   polygonZkEvm = 1101,
   polygonZkEvmTestnet = 1442,


### PR DESCRIPTION
Base Sepolia's chainId is 84532 (https://chainlist.org/chain/84532).